### PR TITLE
Extracting information related to JavaVersionIncompatibility

### DIFF
--- a/breaking-classifier/pom.xml
+++ b/breaking-classifier/pom.xml
@@ -25,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <!-- Plugin to execute the main class -->

--- a/breaking-classifier/src/main/java/se/kth/JavaVersionFinder.java
+++ b/breaking-classifier/src/main/java/se/kth/JavaVersionFinder.java
@@ -1,0 +1,128 @@
+package se.kth;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JavaVersionFinder {
+    public Map<String, List<Integer>> findJavaVersions(String projectPath) {
+        Map<String, List<Integer>> javaVersions = new HashMap<>();
+        File projectFolder = new File(projectPath);
+        if (!projectFolder.exists() || !projectFolder.isDirectory()) {
+            //
+            System.out.println("Folder not exist " + projectPath + " or is not a directory.");
+            return null;
+        }
+        searchJavaVersionsInFolder(projectFolder, javaVersions);
+        return javaVersions;
+    }
+
+    private void searchJavaVersionsInFolder(File folder, Map<String, List<Integer>> javaVersions) {
+        File[] files = folder.listFiles();
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            if (file.isDirectory()) {
+                searchJavaVersionsInFolder(file, javaVersions);
+            } else if (file.getName().endsWith(".yml") || file.getName().contains((".yaml"))) {
+                List<Integer> versions = getJavaVersionsFromFile(file);
+                if (!versions.isEmpty()) {
+                    javaVersions.put(file.getName(), versions);
+                }
+            }
+        }
+    }
+
+
+    private List<Integer> getJavaVersionsFromFile(File file) {
+        List<Integer> versions = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // Patter to search example "java: [ '8', '17', '18' ]"
+                Pattern pattern = Pattern.compile("java:\\s*\\[\\s*'(\\d+)'(?:\\s*,\\s*'\\d+')*\\s*]");
+                Matcher matcher = pattern.matcher(line);
+                while (matcher.find()) {
+                    String match = matcher.group(0); // Get the complete string of the pattern
+                    Pattern numberPattern = Pattern.compile("'(\\d+)'"); // Pattern to extract the numbers
+                    Matcher numberMatcher = numberPattern.matcher(match);
+                    while (numberMatcher.find()) {
+                        int number = Integer.parseInt(numberMatcher.group(1)); // Get the number
+                        if (!versions.contains(number)) {
+                            versions.add(number);
+                        }
+                    }
+                }
+
+                pattern = Pattern.compile("java:\\s*\\[\\s*(\\d+)(?:\\s*,\\s*(\\d+))*\\s*]");
+                matcher = pattern.matcher(line);
+                while (matcher.find()) {
+                    String match = matcher.group(0); // Get the complete string of the pattern
+                    Pattern numberPattern = Pattern.compile("(\\d+)"); // Pattern to extract the numbers
+                    Matcher numberMatcher = numberPattern.matcher(match);
+                    while (numberMatcher.find()) {
+                        int number = Integer.parseInt(numberMatcher.group(1)); // Get the number
+                        if (!versions.contains(number)) {
+                            versions.add(number);
+                        }
+                    }
+                }
+
+                pattern = Pattern.compile("java_version:\\s*\\[\\s*(\\d+)(?:\\s*,\\s*(\\d+))*\\s*]");
+
+                matcher = pattern.matcher(line);
+                while (matcher.find()) {
+                    String match = matcher.group(0); // Get the complete string of the pattern
+                    Pattern numberPattern = Pattern.compile("(\\d+)"); // Pattern to extract the numbers
+                    Matcher numberMatcher = numberPattern.matcher(match);
+
+                    while (numberMatcher.find()) {
+                        int number = Integer.parseInt(numberMatcher.group(1)); // Get the number
+
+                        if (!versions.contains(number)) {
+                            versions.add(number);
+                        }
+                    }
+                }
+
+                // Pattern to search example "java-version: 8"
+                Pattern pattern2 = Pattern.compile("java-version:\\s*(\\d+)");
+                Matcher matcher2 = pattern2.matcher(line);
+                while (matcher2.find()) {
+                    if (!versions.contains(Integer.parseInt(matcher2.group(1)))) {
+                        versions.add(Integer.parseInt(matcher2.group(1)));
+                    }
+                }
+
+                Pattern pattern3 = Pattern.compile("java-version:\\s*'?(\\d+)'?");
+                Matcher matcher3 = pattern3.matcher(line);
+                while (matcher3.find()) {
+                    if (!versions.contains(Integer.parseInt(matcher3.group(1)))) {
+                        versions.add(Integer.parseInt(matcher3.group(1)));
+                    }
+                }
+                Pattern pattern4 = Pattern.compile("java:\\s*\\[\\s*'?(\\d+)'?\\s*,?\\s*'?\\s*]");
+                Matcher matcher4 = pattern4.matcher(line);
+                while (matcher4.find()) {
+                    if (!versions.contains(Integer.parseInt(matcher4.group(1)))) {
+                        versions.add(Integer.parseInt(matcher4.group(1)));
+                    }
+                }
+
+            }
+        } catch (IOException e) {
+            System.out.println("Fail to read file " + file.getAbsolutePath() + ": " + e.getMessage());
+        }
+        return versions;
+    }
+
+}

--- a/breaking-classifier/src/main/java/se/kth/JavaVersionInformation.java
+++ b/breaking-classifier/src/main/java/se/kth/JavaVersionInformation.java
@@ -1,0 +1,154 @@
+package se.kth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.kth.models.JavaVersionIncompatibility;
+import se.kth.models.JavaVersionInfo;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JavaVersionInformation {
+
+    private static final Logger log = LoggerFactory.getLogger(JavaVersionInformation.class);
+    // Start line of the error message to look for in the log file
+    String startLine = "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin";
+
+    // End line of the error message to look for in the log file
+    String endLine = "[ERROR] -> [Help 1]";
+
+    private File logFilePath;
+
+
+    public JavaVersionInformation(File logFilePath) {
+        this.logFilePath = logFilePath;
+    }
+
+    /**
+     * Parse the log file and extract the error messages.
+     *
+     * @param logFilePath The path to the log file.
+     * @return A set of error messages.
+     * @throws IOException If an I/O error occurs.
+     */
+    public Set<String> parseErrors(String logFilePath) throws IOException {
+        Set<String> errors = new HashSet<>();
+        BufferedReader reader = new BufferedReader(new FileReader(logFilePath));
+        StringBuilder currentError = null;
+        String line;
+
+        // Define the regular expression pattern to find error lines
+        Pattern errorPattern = Pattern.compile("\\[ERROR\\] /[\\w\\-/]+\\.java");
+        boolean parseStart = false;
+        while ((line = reader.readLine()) != null) {
+            if (line.startsWith(endLine)) {
+                break;
+            }
+            if (line.startsWith(startLine)) {
+                parseStart = true;
+            }
+            if (parseStart) {
+                Matcher matcher = errorPattern.matcher(line);
+                if (line.startsWith("[ERROR]") && matcher.find()) {
+                    if (currentError != null) {
+                        errors.add(currentError.toString().trim());
+                    }
+                    currentError = new StringBuilder();
+                    currentError.append(line);
+                } else if (currentError != null && !line.trim().isEmpty() && line.contains("  ")) {
+                    // Line with more than one space
+                    currentError.append(System.lineSeparator()).append(line);
+                } else {
+                    // Line that doesn't follow the pattern
+                    if (currentError != null) {
+                        errors.add(currentError.toString().trim());
+                        currentError = null;
+                    }
+                }
+            }
+        }
+
+        if (currentError != null) {
+            errors.add(currentError.toString().trim());
+        }
+
+        reader.close();
+        return errors;
+    }
+
+    /**
+     * Extract version incompatibility errors from the set of error messages.
+     *
+     * @param errors A set of error messages.
+     * @return A map of JavaVersionIncompatibility to a set of error messages.
+     */
+    public Map<JavaVersionIncompatibility, Set<String>> extractVersionErrors(Set<String> errors) {
+        Map<JavaVersionIncompatibility, Set<String>> versionErrors = new HashMap<>();
+
+        // Define the regular expression pattern to find version incompatibility errors
+        Pattern versionPattern = Pattern.compile("class file has wrong version (\\d+\\.\\d+), should be (\\d+\\.\\d+)");
+
+        for (String error : errors) {
+            Matcher versionMatcher = versionPattern.matcher(error);
+            while (versionMatcher.find()) {
+                JavaVersionIncompatibility j = new JavaVersionIncompatibility(versionMatcher.group(1), versionMatcher.group(2), error);
+
+                if (versionErrors.containsKey(j)) {
+                    versionErrors.get(j).add(error);
+                } else {
+                    Set<String> errorSet = new HashSet<>();
+                    errorSet.add(error);
+                    versionErrors.put(j, errorSet);
+                }
+            }
+        }
+        return versionErrors;
+    }
+
+    /**
+     * Analyzes the log file and client path to gather Java version information and incompatibility errors.
+     *
+     * @param logFilePath The path to the log file.
+     * @param clientPath  The path to the client directory.
+     * @return A JavaVersionInfo object containing the analysis results.
+     */
+    public JavaVersionInfo analyse(String logFilePath, String clientPath) {
+
+        // Create an instance of JavaVersionFinder to find Java versions in the client path
+        JavaVersionFinder javaVersionFinder = new JavaVersionFinder();
+
+        // Find Java versions in the client path
+        Map<String, List<Integer>> javaVersions = javaVersionFinder.findJavaVersions(clientPath);
+
+        // Create a new JavaVersionInfo object to store the analysis results
+        JavaVersionInfo javaVersionFailure = new JavaVersionInfo();
+
+        try {
+            // Parse errors from the log file
+            Set<String> errors = parseErrors(logFilePath);
+            // Extract version incompatibility errors from the parsed errors
+            Map<JavaVersionIncompatibility, Set<String>> versionFailures = extractVersionErrors(errors);
+
+            // Set the Java versions found in workflow files
+            javaVersionFailure.setJavaInWorkflowFiles(javaVersions);
+            // Set the version incompatibility errors
+            javaVersionFailure.setDiffVersionErrors(versionFailures);
+            // Set the error messages
+            javaVersionFailure.setErrorMessages(errors);
+            // Set the incompatibility version
+            javaVersionFailure.setIncompatibilityVersion();
+
+        } catch (IOException e) {
+            // Log an error message and rethrow the exception as a RuntimeException
+            log.error("Error parsing log file", e);
+            throw new RuntimeException(e);
+        }
+        // Return the JavaVersionInfo object containing the analysis results
+        return javaVersionFailure;
+    }
+}

--- a/breaking-classifier/src/main/java/se/kth/MavenErrorInformation.java
+++ b/breaking-classifier/src/main/java/se/kth/MavenErrorInformation.java
@@ -1,6 +1,7 @@
 package se.kth;
 
 import se.kth.models.ErrorInfo;
+import se.kth.models.MavenErrorLog;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -21,7 +22,7 @@ public class MavenErrorInformation {
     }
 
     protected String generateLogsLink(String projectURL, int step, int lineNumber) {
-        return "".formatted(step, lineNumber);
+        return "git%s%s".formatted(step, lineNumber);
     }
 
     private MavenErrorLog extractLineNumbersWithPaths(String logFilePath) throws IOException {

--- a/breaking-classifier/src/main/java/se/kth/WerrorInformation.java
+++ b/breaking-classifier/src/main/java/se/kth/WerrorInformation.java
@@ -6,6 +6,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import se.kth.models.ErrorInfo;
+import se.kth.models.MavenErrorLog;
 import se.kth.models.WerrorInfo;
 
 import javax.xml.parsers.DocumentBuilder;

--- a/breaking-classifier/src/main/java/se/kth/models/JavaVersionIncompatibility.java
+++ b/breaking-classifier/src/main/java/se/kth/models/JavaVersionIncompatibility.java
@@ -1,0 +1,72 @@
+package se.kth.models;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public record JavaVersionIncompatibility(
+        String wrongVersion,
+        String shouldBeVersion,
+        String errorMessage
+) {
+
+    private static final Logger log = LoggerFactory.getLogger(JavaVersionIncompatibility.class);
+
+    public JavaVersionIncompatibility {
+        if (wrongVersion == null || shouldBeVersion == null) {
+            log.error("Version cannot be null");
+            throw new IllegalArgumentException("Version cannot be null");
+        }
+    }
+
+    public String toString() {
+        return "\n Expected version: " + wrongVersion + "\n, Actual version: " + shouldBeVersion+"\n";
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        JavaVersionIncompatibility other = (JavaVersionIncompatibility) obj;
+        return wrongVersion.equals(other.wrongVersion) && shouldBeVersion.equals(other.shouldBeVersion);
+    }
+
+    public int hashCode() {
+        return wrongVersion.hashCode() + shouldBeVersion.hashCode();
+    }
+
+
+    public String mapVersions(String classVersion) {
+        return switch (classVersion) {
+            case "45.0" -> "Java 1.0";
+            case "45.3" -> "Java 1.1";
+            case "46.0" -> "Java 1.2";
+            case "47.0" -> "Java 1.3";
+            case "48.0" -> "Java 1.4";
+            case "49.0" -> "Java 5";
+            case "50.0" -> "Java 6";
+            case "51.0" -> "Java 7";
+            case "52.0" -> "Java 8";
+            case "53.0" -> "Java 9";
+            case "54.0" -> "Java 10";
+            case "55.0" -> "Java 11";
+            case "56.0" -> "Java 12";
+            case "57.0" -> "Java 13";
+            case "58.0" -> "Java 14";
+            case "59.0" -> "Java 15";
+            case "60.0" -> "Java 16";
+            case "61.0" -> "Java 17";
+            case "62.0" -> "Java 18";
+            case "63.0" -> "Java 19";
+            case "64.0" -> "Java 20";
+            case "65.0" -> "Java 21";
+            case "66.0" -> "Java 22";
+            case "67.0" -> "Java 23";
+            default -> "Unknown version";
+        };
+    }
+}
+
+

--- a/breaking-classifier/src/main/java/se/kth/models/JavaVersionInfo.java
+++ b/breaking-classifier/src/main/java/se/kth/models/JavaVersionInfo.java
@@ -1,0 +1,62 @@
+package se.kth.models;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents information about Java version incompatibilities.
+ */
+@lombok.Getter
+@lombok.Setter
+public class JavaVersionInfo {
+
+    // Both Java version incompatibility
+    private JavaVersionIncompatibility incompatibility;
+    // List of error messages for each Java version incompatibility
+    private Map<JavaVersionIncompatibility, Set<String>> diffVersionErrors;
+    // List of Java versions in the workflow files
+    private Map<String, List<Integer>> javaInWorkflowFiles;
+    // List of error messages
+    private Set<String> errorMessages;
+
+    /**
+     * Default constructor.
+     */
+    public JavaVersionInfo() {
+    }
+
+    /**
+     * Constructs a JavaVersionInfo with the specified incompatibility and workflow files.
+     *
+     * @param incompatibility     the Java version incompatibility
+     * @param javaInWorkflowFiles the Java files in the workflow
+     */
+    public JavaVersionInfo(JavaVersionIncompatibility incompatibility, Map<String, List<Integer>> javaInWorkflowFiles) {
+        this.incompatibility = incompatibility;
+        this.javaInWorkflowFiles = javaInWorkflowFiles;
+    }
+
+    /**
+     * Sets the incompatibility version based on the differences in version errors.
+     */
+    public void setIncompatibilityVersion() {
+        diffVersionErrors.forEach((incompatibility, errors) -> {
+            if (incompatibility == null) {
+                return;
+            }
+            this.incompatibility = incompatibility;
+            return;
+        });
+    }
+
+    @Override
+    public String toString() {
+        return "JavaVersionInfo{" +
+                "incompatibility=" + incompatibility +
+                ",\n diffVersionErrors=" + diffVersionErrors +
+                ",\n javaInWorkflowFiles=" + javaInWorkflowFiles +
+                ",\n errorMessages=" + errorMessages +
+                '}';
+    }
+}

--- a/breaking-classifier/src/main/java/se/kth/models/MavenErrorLog.java
+++ b/breaking-classifier/src/main/java/se/kth/models/MavenErrorLog.java
@@ -1,6 +1,4 @@
-package se.kth;
-
-import se.kth.models.ErrorInfo;
+package se.kth.models;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/breaking-classifier/src/main/java/se/kth/models/WerrorInfo.java
+++ b/breaking-classifier/src/main/java/se/kth/models/WerrorInfo.java
@@ -1,8 +1,6 @@
 package se.kth.models;
 
 
-import se.kth.MavenErrorLog;
-
 import java.io.File;
 import java.util.List;
 

--- a/core/src/main/java/se/kth/BacardiCore.java
+++ b/core/src/main/java/se/kth/BacardiCore.java
@@ -3,6 +3,7 @@ package se.kth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.kth.models.FailureCategory;
+import se.kth.models.JavaVersionInfo;
 import se.kth.models.WerrorInfo;
 
 import java.nio.file.Path;
@@ -29,6 +30,12 @@ public class BacardiCore {
         switch (failureCategory) {
             case JAVA_VERSION_FAILURE:
                 log.info("Java version failure detected.");
+                JavaVersionInformation javaVersionInformation = new JavaVersionInformation(logFile.toFile());
+
+                JavaVersionInfo javaVersionInfo = javaVersionInformation.analyse(logFile.toAbsolutePath().toString(), project.toAbsolutePath().toString());
+
+                log.info("Java version info: {}", javaVersionInfo);
+
                 break;
             case TEST_FAILURE:
                 log.info("Test failure detected.");
@@ -37,8 +44,8 @@ public class BacardiCore {
                 log.info("Werror failure detected.");
                 WerrorInformation werrorInformation = new WerrorInformation(logFile.toFile());
                 try {
-                   WerrorInfo werrorInfo =  werrorInformation.analyzeWerror(project.toString());
-                     log.info("Werror info: {}", werrorInfo);
+                    WerrorInfo werrorInfo = werrorInformation.analyzeWerror(project.toString());
+                    log.info("Werror info: {}", werrorInfo);
                 } catch (Exception e) {
                     log.error("Error extracting warning lines.", e);
                 }


### PR DESCRIPTION
- Extracting the error lines from the logs.
- The Java versions and those required by the dependency are extracted.
- Extraction of the used workflows and the java version declared.