### PR TITLE
Bump: Extract M2 folders from container to local folder

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>se.kth</groupId>
+            <artifactId>test-failures</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli-codegen</artifactId>
             <version>4.7.6</version>
@@ -33,7 +38,6 @@
             <artifactId>docker-build</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-
 
 
     </dependencies>

--- a/core/src/main/java/Util/BreakingUpdateProvider.java
+++ b/core/src/main/java/Util/BreakingUpdateProvider.java
@@ -1,0 +1,24 @@
+package Util;
+
+import se.kth.model.BreakingUpdate;
+import se.kth.models.FailureCategory;
+import se.kth.utils.JsonUtils;
+
+import java.io.File;
+import java.util.List;
+
+import static se.kth.utils.FileUtils.getFilesInDirectory;
+
+
+public class BreakingUpdateProvider {
+
+
+    public static List<BreakingUpdate> getBreakingUpdatesFromResourcesByCategory(String directory, FailureCategory category) {
+        List<File> files = getFilesInDirectory(directory);
+        return files.stream()
+                .map(File::toPath)
+                .map(e -> JsonUtils.readFromFile(e, BreakingUpdate.class))
+                .filter(breakingUpdate -> breakingUpdate.failureCategory == category)
+                .toList();
+    }
+}

--- a/core/src/main/java/Util/Constants.java
+++ b/core/src/main/java/Util/Constants.java
@@ -1,0 +1,23 @@
+package Util;
+
+public class Constants {
+
+    public static final String MAVEN_LOG_FILE = "maven.log";
+
+    public static final String BENCHMARK_PATH = "/Users/frank/Documents/Work/PHD/BUMP/bump/data/benchmark";
+
+    /**
+     * Path to the projects
+     * for each project, there is a maven.log file and both version of the dependency updated
+     * folder name would be the commit hash
+     *  bd3ce213e2771c6ef7817c80818807a757d4e94a
+     *  |---maven.log
+     *  |---dependency-updated
+     *     |---original
+     *     |---updated
+     *  |-- tar file
+     */
+    public static final String PROJECTS_PATH = "maven.log";
+
+
+}

--- a/core/src/main/java/se/kth/BacardiCore.java
+++ b/core/src/main/java/se/kth/BacardiCore.java
@@ -11,16 +11,16 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
-import static se.kth.Constants.MAVEN_LOG_FILE;
+import static Util.Constants.MAVEN_LOG_FILE;
 
 public class BacardiCore {
 
     private static final Logger log = LoggerFactory.getLogger(BacardiCore.class);
-    private Path project;
+    private final Path project;
 
-    private Path logFile;
+    private final Path logFile;
 
-    private FailureCategoryExtract failureCategoryExtract;
+    private final FailureCategoryExtract failureCategoryExtract;
 
 
     public BacardiCore(Path project, Path logFile, FailureCategoryExtract failureCategoryExtract) {

--- a/core/src/main/java/se/kth/Bump.java
+++ b/core/src/main/java/se/kth/Bump.java
@@ -1,0 +1,80 @@
+package se.kth;
+
+import Util.BreakingUpdateProvider;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.kth.model.BreakingUpdate;
+import se.kth.models.FailureCategory;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static Util.Constants.BENCHMARK_PATH;
+
+public class Bump {
+
+    private static final Logger log = LoggerFactory.getLogger(Bump.class);
+
+    private final static String LOCAL_PATH_M2 = "/Users/frank/Documents/Work/PHD/bacardi/M2";
+
+
+    public static void main(String[] args) {
+
+
+        log.info("");
+        log.info("*********************************************");
+        log.info("Bump analysis started");
+        log.info("*********************************************");
+        log.info("");
+
+
+        //filtering breaking dependency updates
+        log.info("Filtering breaking dependency updates");
+        log.info("");
+
+
+        List<BreakingUpdate> breaking = BreakingUpdateProvider.getBreakingUpdatesFromResourcesByCategory(BENCHMARK_PATH, FailureCategory.COMPILATION_FAILURE);
+
+        log.info("Breaking dependency updates: {}", breaking.size());
+        log.info("");
+        breaking.forEach(e -> log.info("{}", e.breakingCommit));
+        log.info("");
+
+
+        DockerBuild dockerBuild = new DockerBuild();
+        // identify breaking updates and download image and copy the project
+
+        breaking.stream()
+                .filter(e -> e.breakingCommit.equals("c8da6c3c823d745bb37b072a4a33b6342a86dcd9"))
+                .forEach(e -> getProjectData(e, dockerBuild));
+
+    }
+
+
+    private static void getProjectData(BreakingUpdate breakingUpdate, DockerBuild dockerBuild) {
+
+
+        try {
+            String imageId = breakingUpdate.breakingUpdateReproductionCommand.replace("docker run ", "");
+
+            String[] entrypoint = new String[]{"/bin/sh"};
+
+            //pull image
+            dockerBuild.ensureBaseMavenImageExists(imageId);
+
+            CreateContainerResponse container = dockerBuild.startContainerEntryPoint(imageId, entrypoint);
+
+            // Copy m2 folder to local path in the breaking commit folder
+            Path localPath = Path.of("%s/%s".formatted(LOCAL_PATH_M2, breakingUpdate.breakingCommit));
+            dockerBuild.copyM2FolderToLocalPath(container.getId(), localPath);
+
+
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+
+}

--- a/core/src/main/java/se/kth/Constants.java
+++ b/core/src/main/java/se/kth/Constants.java
@@ -1,8 +1,0 @@
-package se.kth;
-
-public class Constants {
-
-    public static final String MAVEN_LOG_FILE = "maven.log";
-
-
-}


### PR DESCRIPTION
### Dependencies:
* Added a new dependency for `test-failures` in the `core/pom.xml` file.

### New Utility Classes:
* Created `BreakingUpdateProvider` to handle breaking updates from resources by category. (`core/src/main/java/Util/BreakingUpdateProvider.java`)
* Introduced `Constants` to store constant values used across the project. (`core/src/main/java/Util/Constants.java`)

### Refactoring:
* Refactored `BacardiCore` to use the new `Constants` class and made some fields final for better immutability. (`core/src/main/java/se/kth/BacardiCore.java`)
* Removed the old `Constants` class from the `se.kth` package. (`core/src/main/java/se/kth/Constants.java`)

### Docker Enhancements:
* Enhanced Docker functionalities by adding methods to start containers with specific entry points and copy the `.m2` folder from containers to the local path. (`docker-build/src/main/java/se/kth/DockerBuild.java`)
* Simplified the file copying logic in the `copyProjectFromContainer` method. (`docker-build/src/main/java/se/kth/DockerBuild.java`)