### PR TITLE
Fixing werror incompatibilities and update the pipeline

### DIFF
--- a/core/src/main/java/se/kth/Util/BreakingUpdateProvider.java
+++ b/core/src/main/java/se/kth/Util/BreakingUpdateProvider.java
@@ -1,5 +1,11 @@
 package se.kth.Util;
 
+import com.fasterxml.jackson.databind.type.MapType;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.kth.DockerBuild;
+import se.kth.Result;
 import se.kth.model.BreakingUpdate;
 import se.kth.models.FailureCategory;
 
@@ -7,15 +13,28 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static se.kth.Util.FileUtils.getFilesInDirectory;
 
 
-public class BreakingUpdateProvider {
+public class  BreakingUpdateProvider {
 
 
+    static Logger log = LoggerFactory.getLogger(DockerBuild.class);
+
+    /**
+     * Retrieves a list of BreakingUpdate objects from the specified directory, filtered by the given category.
+     *
+     * @param directory the directory to search for files
+     * @param category  the category to filter the BreakingUpdate objects
+     * @return a list of BreakingUpdate objects that match the specified category
+     */
     public static List<BreakingUpdate> getBreakingUpdatesFromResourcesByCategory(String directory,
                                                                                  FailureCategory category) {
         List<File> files = getFilesInDirectory(directory);
@@ -25,6 +44,27 @@ public class BreakingUpdateProvider {
                 .filter(breakingUpdate -> breakingUpdate.failureCategory == category)
                 .toList();
     }
+
+
+    /**
+     * Retrieves a list of BreakingUpdate objects from the specified directory, filtered by the given category and additional filter.
+     *
+     * @param directory the directory to search for files
+     * @param category  the category to filter the BreakingUpdate objects
+     * @param filter    an additional filter to apply to the results, such as a list of breaking commits from Bump
+     * @return a list of BreakingUpdate objects that match the specified category and filter
+     */
+    public static List<BreakingUpdate> getBreakingUpdatesFromResourcesByCategory(String directory,
+                                                                                 FailureCategory category, ArrayList<String> filter) {
+        List<File> files = getFilesInDirectory(directory);
+        return files.stream()
+                .map(File::toPath)
+                .map(e -> JsonUtils.readFromFile(e, BreakingUpdate.class))
+                .filter(breakingUpdate -> breakingUpdate.failureCategory == category)
+                .filter(breakingUpdate -> filter.contains(breakingUpdate.breakingCommit))
+                .toList();
+    }
+
 
     public static ArrayList<String> readLinesFromFile(String filePath) {
         ArrayList<String> lines = new ArrayList<>();
@@ -37,17 +77,66 @@ public class BreakingUpdateProvider {
                 lines.add(line);
             }
         } catch (IOException e) {
-            e.printStackTrace();  // Handle the exception as needed
+            log.error("Error reading file: {}", e.getMessage(), e);
+
         } finally {
             try {
                 if (reader != null) {
                     reader.close();
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error closing file: {}", e.getMessage(), e);
             }
         }
 
         return lines;
     }
+
+
+    public static ArrayList<String> readJavaVersionIncompatibilities(String filePath) {
+        //enable filter for only specific breaking update category
+        return readLinesFromFile(filePath);
+    }
+
+    public static Map<String, Result> getPreviousResults(String jsonPath) {
+        final var path = Path.of(jsonPath);
+        MapType jsonType = JsonUtils.getTypeFactory().constructMapType(Map.class, String.class, Result.class);
+        Map<String, Result> resultsMap = new HashMap<>();
+
+
+        if (!Files.exists(path)) {
+            try {
+                //create empty file
+                Files.createFile(path);
+                JsonUtils.writeToFile(path, resultsMap);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        resultsMap.putAll(JsonUtils.readFromFile(path, jsonType));
+
+        return resultsMap;
+
+    }
+
+    public static String getProjectData(BreakingUpdate breakingUpdate, DockerBuild dockerBuild, Path fromContainer, Path toLocal) {
+
+        String imageId = null;
+        try {
+            imageId = breakingUpdate.breakingUpdateReproductionCommand.replace("docker run ", "");
+            String[] entrypoint = new String[]{"/bin/sh"};
+
+            //pull image
+            dockerBuild.ensureBaseMavenImageExists(imageId);
+            CreateContainerResponse container = dockerBuild.startContainerEntryPoint(imageId, entrypoint);
+            // Copy m2 folder to local path in the breaking commit folder
+            dockerBuild.copyM2FolderToLocalPath(container.getId(), fromContainer, toLocal);
+            dockerBuild.removeContainer(container.getId());
+            return imageId;
+        } catch (InterruptedException e) {
+            log.error("Something went wrong", e);
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/core/src/main/java/se/kth/Util/Constants.java
+++ b/core/src/main/java/se/kth/Util/Constants.java
@@ -6,16 +6,19 @@ public class Constants {
 
     public static final String BENCHMARK_PATH = "/Users/frank/Documents/Work/PHD/BUMP/bump/data/benchmark";
 
+    public static final String JAVA_VERSION_INCOMPATIBILITY_FILE = "/Users/frank/Documents/Work/PHD/BUMP/bump-execution/analysis/client_fail_due_java_version_incompatibility.txt";
+
+
     /**
      * Path to the projects
      * for each project, there is a maven.log file and both version of the dependency updated
      * folder name would be the commit hash
-     *  bd3ce213e2771c6ef7817c80818807a757d4e94a
-     *  |---maven.log
-     *  |---dependency-updated
-     *     |---original
-     *     |---updated
-     *  |-- tar file
+     * bd3ce213e2771c6ef7817c80818807a757d4e94a
+     * |---maven.log
+     * |---dependency-updated
+     * |---original
+     * |---updated
+     * |-- tar file
      */
     public static final String PROJECTS_PATH = "maven.log";
 

--- a/core/src/main/java/se/kth/model/SetupPipeline.java
+++ b/core/src/main/java/se/kth/model/SetupPipeline.java
@@ -1,0 +1,29 @@
+package se.kth.model;
+
+
+import se.kth.DockerBuild;
+
+import java.nio.file.Path;
+
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+
+public class SetupPipeline {
+
+    String dockerImage;
+    Path clientFolder;
+    Path logFilePath;
+    String branch;
+    Path m2FolderPath;
+    DockerBuild dockerBuild;
+    BreakingUpdate breakingUpdate;
+
+
+    public SetupPipeline() {
+    }
+
+
+
+
+}

--- a/core/src/main/java/se/kth/repair/RepairPipeline.java
+++ b/core/src/main/java/se/kth/repair/RepairPipeline.java
@@ -1,0 +1,13 @@
+package se.kth.repair;
+
+public interface RepairPipeline {
+
+    /**
+     * Repair the project
+     *
+     * @param dockerImage The docker image to use
+     * @param projectPath The path to the project
+     * @param logFilePath The path to the log file
+     */
+    public abstract void repair(String dockerImage, String projectPath, String logFilePath);
+}

--- a/docker-build/pom.xml
+++ b/docker-build/pom.xml
@@ -18,16 +18,16 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
-            <version>3.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-transport-okhttp</artifactId>
-            <version>3.3.3</version>
-        </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-okhttp</artifactId>
+                <version>3.3.3</version>
+            </dependency>
         <dependency>
             <groupId>se.kth</groupId>
             <artifactId>breaking-classifier</artifactId>

--- a/docker-build/src/main/java/se/kth/Attempt.java
+++ b/docker-build/src/main/java/se/kth/Attempt.java
@@ -1,21 +1,23 @@
 package se.kth;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import se.kth.models.FailureCategory;
 
-public record Attempt(
-        int index,
-        FailureCategory failureCategory,
-        boolean isSuccessful
-) {
-
-
-    @Override
-    public String toString() {
-        return "Attempt{" +
-                "index=" + index +
-                ", failureCategory=" + failureCategory +
-                ", isSuccessful=" + isSuccessful +
-                '}';
+/**
+ * @param index Getters
+ */
+public record Attempt(@Getter int index, @Getter FailureCategory failureCategory, boolean isSuccessful) {
+    @JsonCreator
+    public Attempt(
+            @JsonProperty("index") int index,
+            @JsonProperty("failureCategory") FailureCategory failureCategory,
+            @JsonProperty("isSuccessful") boolean isSuccessful) {
+        this.index = index;
+        this.failureCategory = failureCategory;
+        this.isSuccessful = isSuccessful;
     }
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>core</module>
         <module>git-manager</module>
         <module>test-failures</module>
+        <module>spoon-analyzer</module>
     </modules>
 
 

--- a/spoon-analyzer/pom.xml
+++ b/spoon-analyzer/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>se.kth</groupId>
+        <artifactId>bacardi</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spoon-analyzer</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>


### PR DESCRIPTION
Changes include adding a new constructor to `BacardiCore`, modifying methods to use `SetupPipeline`, and refactoring the `Bump` class to utilize the new `SetupPipeline` model. Additionally, utility methods have been added to `BreakingUpdateProvider` to support these changes.

Key changes include:

### Integration of `SetupPipeline` model:
* Added `SetupPipeline` field and constructor to `BacardiCore` to initialize and verify paths (`core/src/main/java/se/kth/BacardiCore.java`). [[1]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6R25) [[2]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6R40-L42)
* Modified `verify`, `analyze`, and `repairJavaVersionIncompatibility` methods in `BacardiCore` to use paths from `SetupPipeline` (`core/src/main/java/se/kth/BacardiCore.java`). [[1]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6L51-R62) [[2]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6L118-R128) [[3]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6L129-R140)

### Refactoring of `Bump` class:
* Refactored `Bump` class to use `SetupPipeline` for managing paths and docker images (`core/src/main/java/se/kth/Bump.java`). [[1]](diffhunk://#diff-b37ae2fe67cd269a8b922a3bf256cdf1636c2682ab1d2e610a26a897f8d23520L39-R88) [[2]](diffhunk://#diff-b37ae2fe67cd269a8b922a3bf256cdf1636c2682ab1d2e610a26a897f8d23520R97-R123)
* Added methods to `BreakingUpdateProvider` to read Java version incompatibilities and get previous results (`core/src/main/java/se/kth/Util/BreakingUpdateProvider.java`). [[1]](diffhunk://#diff-350b3fc42b598ae108fc9643607429797d560bfe118e431fc1cbc6860f1643e3R3-R37) [[2]](diffhunk://#diff-350b3fc42b598ae108fc9643607429797d560bfe118e431fc1cbc6860f1643e3L40-R141)

### Utility and constants updates:
* Added new constant for Java version incompatibility file path (`core/src/main/java/se/kth/Util/Constants.java`).
* Updated `RepairJavaVersionIncompatibility` to accept `SetupPipeline` as a parameter (`core/src/main/java/se/kth/java_version/RepairJavaVersionIncompatibility.java`).