### PR TITLE
Adding process to identify dependency conflicts in maven dependency tree

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>docker-build</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-api-impl</artifactId>
+            <version>4.0.0-beta-4</version>
+            <scope>compile</scope>
+        </dependency>
 
 
     </dependencies>

--- a/core/src/main/java/se/kth/Bump.java
+++ b/core/src/main/java/se/kth/Bump.java
@@ -55,8 +55,9 @@ public class Bump {
 
         breaking
                 .stream()
-                .filter(e -> e.breakingCommit.equals("bdbb81614557858922836294d1d6dd3dd661f10c")) // filter by breaking commit
-//                .filter(e -> javaVersionIncompatibilityLines.contains(e.breakingCommit)) // filter by failure category
+
+//                .filter(e -> e.breakingCommit.equals("43b3a858b77ec27fc8946aba292001c3de465012")) // filter by breaking commit
+                .filter(e -> !listOfJavaVersionIncompatibilities.contains(e.breakingCommit)) // filter by failure category
                 .forEach(e -> {
 
                     //starting processing breaking update

--- a/core/src/main/java/se/kth/Util/ParserResults.java
+++ b/core/src/main/java/se/kth/Util/ParserResults.java
@@ -1,0 +1,29 @@
+package se.kth.Util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class ParserResults {
+
+    static Logger log = LoggerFactory.getLogger(ParserResults.class);
+
+    public static boolean searchPatternInFile(String filePath, String pattern) {
+        try {
+            List<String> lines = Files.readAllLines(Path.of(filePath));
+            for (String line : lines) {
+                if (line.contains(pattern)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            log.error("Error reading file", e);
+        }
+        return false;
+    }
+
+}

--- a/core/src/main/java/se/kth/direct_failures/RepairDirectFailures.java
+++ b/core/src/main/java/se/kth/direct_failures/RepairDirectFailures.java
@@ -1,0 +1,114 @@
+package se.kth.direct_failures;
+
+import org.apache.maven.api.model.Model;
+import org.apache.maven.model.v4.MavenStaxWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.kth.DockerBuild;
+import se.kth.model.DependencyTree;
+import se.kth.model.SetupPipeline;
+import se.kth.models.FailureCategory;
+import se.kth.parse.ParseMavenDependencyTree;
+import se.kth.parse.PomModel;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+public class RepairDirectFailures {
+
+    private static Logger log = LoggerFactory.getLogger(RepairDirectFailures.class);
+    private final DockerBuild dockerBuild;
+
+    private final String groupId;
+    private final String artifactId;
+    private SetupPipeline setupPipeline;
+
+
+    public RepairDirectFailures(DockerBuild dockerBuild, String groupId, String artifactId, SetupPipeline setupPipeline) {
+        this.dockerBuild = dockerBuild;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.setupPipeline = setupPipeline;
+    }
+
+
+    public Path generateDependencyTree(Path treeFile, String dockerImage, String projectPath) {
+
+        String[] command = {"/bin/sh", "-c", "mvn dependency:3.7.0:tree -DoutputType=json -Dverbose=true -DoutputFile=tree.json"};
+
+        String containerId = dockerBuild.startSpinningContainer(dockerImage);
+
+        String outputExecution = dockerBuild.executeInContainer(containerId, command);
+        if (outputExecution.contains("BUILD FAILURE")) {
+            log.error("Error while generating dependency tree");
+            return null;
+        }
+        return dockerBuild.copyFromContainer(containerId, projectPath.concat("/tree.json"), treeFile);
+    }
+
+    public List<DependencyTree> identifyConflicts(Path mavenDependencyTreeFile) {
+        List<DependencyTree> dependencyTrees = checkDependencyResolutionConflict(mavenDependencyTreeFile.toString());
+        if (dependencyTrees.isEmpty()) {
+            log.info("No conflicts found");
+        } else {
+            log.info("Conflicts found");
+            dependencyTrees.forEach(dependencyTree -> log.info(dependencyTree.toString()));
+        }
+
+        return dependencyTrees;
+    }
+
+
+    public String reproduce() {
+
+        try {
+            dockerBuild.copyFolderToDockerImage(setupPipeline.getDockerImage(), setupPipeline.getClientFolder().toString());
+
+            Path logFilePath = setupPipeline.getLogFilePath().getParent().resolve("output.log");
+
+            dockerBuild.reproduce(setupPipeline.getDockerImage(), FailureCategory.COMPILATION_FAILURE, setupPipeline.getClientFolder(), logFilePath);
+
+            setupPipeline.setLogFilePath(logFilePath);
+
+            return setupPipeline.getDockerImage();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public static void modifyPomFile(Path pomFile, DependencyTree dependencyTree) throws IOException {
+        //
+        PomModel pomModel = new PomModel(pomFile);
+        File pom = new File(pomFile.toString());
+        File backupPomFile = new File(pomFile.toString().replace(".xml", "_backup.xml"));
+        Files.copy(pom.toPath(), backupPomFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        try {
+            Model newModel = pomModel.modifyDependency(dependencyTree);
+
+            //create new pom file
+            OutputStream outputStream = Files.newOutputStream(pomFile);
+            MavenStaxWriter writer = new MavenStaxWriter();
+            writer.write(outputStream, newModel);
+        } catch (IOException | XMLStreamException e) {
+            log.error("Error modifying the pom file", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public List<DependencyTree> checkDependencyResolutionConflict(String dependencyTreePath) {
+
+        ParseMavenDependencyTree parseMavenDependencyTree = new ParseMavenDependencyTree(dependencyTreePath);
+        List<DependencyTree> dependencies = parseMavenDependencyTree.parseDependencies();
+        List<DependencyTree> children = parseMavenDependencyTree.findChildrenByName(dependencies, groupId, artifactId);
+        return parseMavenDependencyTree.hasSameOrLowerLevelDependencies(dependencies, children);
+    }
+}

--- a/core/src/main/java/se/kth/model/ConflictedDependencies.java
+++ b/core/src/main/java/se/kth/model/ConflictedDependencies.java
@@ -1,0 +1,33 @@
+package se.kth.model;
+
+import java.util.Objects;
+
+/**
+ * This class is used to represent a dependency that is in conflict with the client's dependency.
+ * To resolve the conflict, the client's dependency must be updated to a version that is compatible with the child dependency.
+ * <p>To solve the conflict:
+ * <ul>
+ *     <li>Update the client's dependency to a version that is defined in the child dependency.</li>
+ *     <li>Add a new dependency in the client's pom.xml file</li>
+ * </ul>
+ * </p>
+ */
+@lombok.Getter
+@lombok.Setter
+@lombok.EqualsAndHashCode
+@lombok.ToString
+public class ConflictedDependencies {
+
+    // The dependency that is in conflict with the client dependency
+    // In most of the cases, this is a transitive dependency of the client's dependency
+    private DependencyTree child;
+
+    // The client dependency that is in conflict with the child dependency
+    // This is the dependency that is in the client's pom.xml file or as a transitive dependency from another dependency in the client's pom.xml file
+    private DependencyTree clientDependency;
+
+    public ConflictedDependencies(DependencyTree child, DependencyTree clientDependency) {
+        this.child = Objects.requireNonNull(child, "The child dependency cannot be null");
+        this.clientDependency = Objects.requireNonNull(clientDependency, "The client dependency cannot be null");
+    }
+}

--- a/core/src/main/java/se/kth/model/Dependency.java
+++ b/core/src/main/java/se/kth/model/Dependency.java
@@ -1,12 +1,18 @@
 package se.kth.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@lombok.Getter
+@lombok.Setter
 public class Dependency {
+
 
     public final String groupId;
     public final String artifactId;
-    public final String version;
+    public String version;
     public final String scope;
     public final String type;
+
 
 
     public Dependency(String groupId, String artifactId, String version, String type, String scope) {
@@ -15,7 +21,14 @@ public class Dependency {
         this.version = version;
         this.scope = scope;
         this.type = type;
+    }
 
+    public Dependency(){
+        this.groupId = "";
+        this.artifactId = "";
+        this.version = "";
+        this.scope = "";
+        this.type = "";
     }
 
     @Override

--- a/core/src/main/java/se/kth/model/DependencyTree.java
+++ b/core/src/main/java/se/kth/model/DependencyTree.java
@@ -1,0 +1,49 @@
+package se.kth.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@lombok.Getter
+@lombok.Setter
+@EqualsAndHashCode(callSuper = false)
+public class DependencyTree extends Dependency {
+
+
+    @JsonProperty("children")
+    private List<DependencyTree> children;
+    @JsonProperty("classifier")
+    private String classifier;
+    @JsonProperty("optional")
+    private String optional;
+    private int level;
+    private DependencyTree parent;
+    private int treePosition;
+
+    public DependencyTree(String groupId, String artifactId, String version, String type, String scope, List<DependencyTree> children) {
+        super(groupId, artifactId, version, type, scope);
+    }
+
+    public DependencyTree(String groupId, String artifactId, String version, String type, String scope, String classifier, List<DependencyTree> children, int level, DependencyTree parent, String optional) {
+        super(groupId, artifactId, version, type, scope);
+        this.classifier = classifier;
+        this.children = children;
+        this.level = level;
+        this.parent = parent;
+        this.optional = optional;
+    }
+
+    public DependencyTree() {
+        super();
+    }
+
+
+    @Override
+    public String toString() {
+        return "DependencyTree{" + "groupId='" + getGroupId() + '\'' + ", artifactId='" + getArtifactId() + '\'' + ", version='" + getVersion() + '\'' +
+                ", type='" + getType() + '\'' + ", scope='" + getScope() + '\'' + ", classifier='" + classifier + '\'' + ", optional='" + optional + '\'' +
+                ", level=" + level + ", parent=" + parent + ", treePosition=" + treePosition + '}';
+    }
+
+}

--- a/core/src/main/java/se/kth/parse/ParseMavenDependencyTree.java
+++ b/core/src/main/java/se/kth/parse/ParseMavenDependencyTree.java
@@ -1,0 +1,129 @@
+package se.kth.parse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.kth.model.DependencyTree;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ParseMavenDependencyTree {
+
+    private final Logger log = LoggerFactory.getLogger(ParseMavenDependencyTree.class);
+
+    private final String filePath;
+
+
+    public ParseMavenDependencyTree(String filePath) {
+        this.filePath = Objects.requireNonNull(filePath);
+    }
+
+
+    /**
+     * Parses the Maven dependency tree from the JSON file specified by the file path.
+     * Using -DoutputType=json without -Dverbose option in mvn dependency:tree command
+     *
+     * @return a list of DependencyTree objects representing the parsed dependencies
+     */
+    public List<DependencyTree> parseDependencies() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<DependencyTree> dependencies = new ArrayList<>();
+        try {
+            DependencyTree rootDependency = objectMapper.readValue(new File(filePath), DependencyTree.class);
+            populateDependencies(rootDependency, 0, null, dependencies, new int[]{1});
+        } catch (IOException e) {
+            log.error("Error parsing the Maven dependency tree from the file: {}", filePath, e);
+        }
+        return dependencies;
+    }
+
+    /**
+     * Populates the dependencies list with the given dependency and its children.
+     *
+     * @param dependency       the root dependency to start populating from
+     * @param level            the current level of the dependency in the tree
+     * @param parent           the parent dependency of the current dependency
+     * @param dependencies     the list to populate with dependencies
+     * @param levelOnePosition an array to keep track of the position of level 1 dependencies
+     */
+    public void populateDependencies(DependencyTree dependency, int level, DependencyTree parent, List<DependencyTree> dependencies, int[] levelOnePosition) {
+        dependency.setLevel(level);
+        dependency.setParent(parent);
+
+        // if the dependency is at level 1, set its tree position and increment the position counter
+        // this information help to understand the position of the dependency in the tree and decide if we need to modify or add a new dependency
+        if (level == 1) {
+            dependency.setTreePosition(levelOnePosition[0]++);
+        } else {
+            dependency.setTreePosition(-1);
+        }
+
+        dependencies.add(dependency);
+        if (dependency.getChildren() != null) {
+            for (DependencyTree child : dependency.getChildren()) {
+                populateDependencies(child, level + 1, dependency, dependencies, levelOnePosition);
+            }
+        }
+    }
+
+    /**
+     * Finds the children of a {@link DependencyTree} by its groupId and artifactId.
+     *
+     * @param dependencies the list of {@link DependencyTree} to search through
+     * @param groupId      the groupId of the dependency to find
+     * @param artifactId   the artifactId of the dependency to find
+     * @return a list of children {@link DependencyTree}, or an empty list if no match is found
+     */
+    public List<DependencyTree> findChildrenByName(List<DependencyTree> dependencies, String groupId, String artifactId) {
+        for (DependencyTree dependency : dependencies) {
+            if (dependency.getGroupId().equals(groupId) && dependency.getArtifactId().equals(artifactId)) {
+                return dependency.getChildren();
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Finds dependencies that have the same or lower level than the given children dependencies,
+     * but with a different version.
+     *
+     * @param dependencies the list of all dependencies to search through
+     * @param children     the list of child dependencies to compare against
+     * @return a list of {@link DependencyTree} that have the same or lower level than the children, but with a different version
+     */
+    public List<DependencyTree> hasSameOrLowerLevelDependencies(List<DependencyTree> dependencies, List<DependencyTree> children) {
+
+        List<DependencyTree> sameOrLowerLevelDependencies = new ArrayList<>();
+        for (DependencyTree child : children) {
+            for (DependencyTree dependency : dependencies) {
+                if (dependency.getArtifactId().equals(child.getArtifactId())
+                        && dependency.getLevel() <= child.getLevel()
+                        && !dependency.getVersion().equals(child.getVersion())) {
+                    dependency.setVersion(child.getVersion());
+                    sameOrLowerLevelDependencies.add(dependency);
+                }
+            }
+        }
+        return sameOrLowerLevelDependencies;
+    }
+
+    /**
+     * Prints all level 1 dependencies from the given list of dependencies.
+     *
+     * @param dependencies the list of {@link DependencyTree} to search through
+     */
+    public void printLevelOneDependencies(List<DependencyTree> dependencies) {
+        for (DependencyTree dependency : dependencies) {
+            if (dependency.getLevel() == 1) {
+                System.out.println("Dependency: " + dependency.getGroupId() + ":" + dependency.getArtifactId() + " at position: " + dependency.getTreePosition());
+            }
+        }
+    }
+
+
+
+}

--- a/core/src/main/java/se/kth/parse/PomModel.java
+++ b/core/src/main/java/se/kth/parse/PomModel.java
@@ -1,0 +1,52 @@
+package se.kth.parse;
+
+import org.apache.maven.api.model.Dependency;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.model.v4.MavenStaxReader;
+import org.apache.maven.model.v4.MavenStaxWriter;
+import se.kth.model.DependencyTree;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PomModel {
+
+    private final Model model;
+
+    public PomModel(Path pomFilePath) {
+        model = parsePomFile(pomFilePath);
+    }
+
+    public Model parsePomFile(Path pomFilePath) {
+        MavenStaxReader reader = new MavenStaxReader();
+        try (InputStream inputStream = Files.newInputStream(pomFilePath)) {
+            return reader.read(inputStream);
+        } catch (IOException | XMLStreamException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Model modifyDependency(DependencyTree dependencyTree) throws IOException, XMLStreamException {
+        List<Dependency> dependencyList = new ArrayList<>(model.getDependencies());
+        boolean dependencyExists = false;
+
+        for (Dependency dependency : dependencyList) {
+            if (dependency.getArtifactId().equals(dependencyTree.getArtifactId()) && dependency.getGroupId().equals(dependencyTree.getGroupId())) {
+                System.out.println("Dependency exists");
+                Dependency withNewVersion = dependency.withVersion(dependencyTree.getVersion());
+                int index = dependencyList.indexOf(dependency);
+                dependencyList.set(index, withNewVersion);
+                break;
+            }
+        }
+
+     return model.withDependencies(dependencyList);
+    }
+}

--- a/core/src/main/java/se/kth/parse/TestParser.java
+++ b/core/src/main/java/se/kth/parse/TestParser.java
@@ -1,0 +1,33 @@
+package se.kth.parse;
+
+import se.kth.direct_failures.RepairDirectFailures;
+import se.kth.model.DependencyTree;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class TestParser {
+    public static void main(String[] args) {
+
+        ParseMavenDependencyTree parseMavenDependencyTree = new ParseMavenDependencyTree("/Users/frank/Documents/Work/PHD/bacardi/projects/bd3ce213e2771c6ef7817c80818807a757d4e94a/OCR4all/tree.json");
+
+
+        List<DependencyTree> dependencies = parseMavenDependencyTree.parseDependencies();
+        List<DependencyTree> children = parseMavenDependencyTree.findChildrenByName(dependencies, "com.fasterxml.jackson.core", "jackson-databind");
+        List<DependencyTree> hasSameOrLowerLevelDependencies = parseMavenDependencyTree.hasSameOrLowerLevelDependencies(dependencies, children);
+        System.out.println("Children: " + children);
+        System.out.println("Has same or lower level dependencies: " + hasSameOrLowerLevelDependencies);
+
+//        PomModel pomModel = new PomModel();
+
+        try {
+//            pomModel.modifyDependency(hasSameOrLowerLevelDependencies.get(0));
+            RepairDirectFailures.modifyPomFile(Path.of("/Users/frank/Documents/Work/PHD/bacardi/projects/bd3ce213e2771c6ef7817c80818807a757d4e94a/OCR4all/pom.xml"), hasSameOrLowerLevelDependencies.get(0));
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/docker-build/src/main/java/se/kth/Attempt.java
+++ b/docker-build/src/main/java/se/kth/Attempt.java
@@ -9,15 +9,15 @@ import se.kth.models.FailureCategory;
 /**
  * @param index Getters
  */
-public record Attempt(@Getter int index, @Getter FailureCategory failureCategory, boolean isSuccessful) {
+public record Attempt(@Getter int index, @Getter FailureCategory failureCategory, boolean successful) {
     @JsonCreator
     public Attempt(
             @JsonProperty("index") int index,
             @JsonProperty("failureCategory") FailureCategory failureCategory,
-            @JsonProperty("isSuccessful") boolean isSuccessful) {
+            @JsonProperty("successful") boolean successful) {
         this.index = index;
         this.failureCategory = failureCategory;
-        this.isSuccessful = isSuccessful;
+        this.successful = successful;
     }
 }
 

--- a/git-manager/src/main/java/se/kth/Constants.java
+++ b/git-manager/src/main/java/se/kth/Constants.java
@@ -5,4 +5,5 @@ public class Constants {
     public static final String BRANCH_JAVA_VERSION_INCOMPATIBILITY = "repair_java_version_incompatibility";
     public static final String BRANCH_WERROR = "repair_werror";
     public static final String BRANCH_ORIGINAL_STATUS = "original_status";
+    public static final String BRANCH_DIRECT_COMPILATION_FAILURE = "repair_direct_compilation_failure";
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the BacardiCore project, focusing on dependency management, error handling, and the addition of new utility classes. The most important changes include adding a new dependency to the `pom.xml` file, implementing a new method to handle direct compilation failures, and creating several new classes to manage dependencies and parse Maven dependency trees.

Dependency Management and Error Handling:

* [`core/pom.xml`](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR41-R46): Added a new dependency for `maven-api-impl` to the project dependencies.
* [`core/src/main/java/se/kth/BacardiCore.java`](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6R95): Implemented the `repairDirectCompilationFailure` method to handle direct compilation failures and modified the `analyze` method to use this new method. [[1]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6R95) [[2]](diffhunk://#diff-073e92ba9dcebc65e53d26eacc34a421e55b5aff2e9514e153ade24f908a42f6L115-R195)

New Utility Classes:

* [`core/src/main/java/se/kth/Util/ParserResults.java`](diffhunk://#diff-440384ea3ddb6fdee04b6ae0b6c2630ff967f4ff8ff1b95afc825d73c4ba71a0R1-R29): Added a new utility class `ParserResults` to search for patterns in files.
* [`core/src/main/java/se/kth/direct_failures/RepairDirectFailures.java`](diffhunk://#diff-68928342fe91affc869a2c3b61a34641da53aed8f22df391daeb89d458296240R1-R114): Created a new class `RepairDirectFailures` to manage and repair direct compilation failures, including methods for generating dependency trees and modifying `pom.xml` files.

Dependency Tree Management:

* [`core/src/main/java/se/kth/model/DependencyTree.java`](diffhunk://#diff-9f59636971501b7217b0a886e6eba780d58ae74c1afe6607b0dac94bcf824b87R1-R49): Added a new class `DependencyTree` to represent and manage Maven dependency trees.
* [`core/src/main/java/se/kth/parse/ParseMavenDependencyTree.java`](diffhunk://#diff-69008138970fd654484cbfe88a8a1702a4f7000734d47d5fc3d30894cf2c1e31R1-R129): Introduced a new class `ParseMavenDependencyTree` to parse Maven dependency trees from JSON files and identify conflicts.